### PR TITLE
Autoscroll in script when changing node

### DIFF
--- a/src/tsx/coreConnection.tsx
+++ b/src/tsx/coreConnection.tsx
@@ -45,18 +45,29 @@ class DummyCoreConnection extends EventTarget implements ICoreConnection {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(address: string) {
     super();
+    // TODO: Use real lines with correct locations
     this.nodes = {
-      a: {
-        next: "b",
-        prompt: "Välkommen till Kulturkrocks senaste föreställning!",
+      "11": {
+        next: "160",
+        prompt:
+          "Jag har hört att han är dömd att segla de sju haven för alltid i en fruktlös jakt på sin älskade!",
+        pdfPage: 2,
+        pdfLocationOnPage: 0.6,
       },
-      b: { next: "c", prompt: "Jag ser att ni fortfarande är på väg in." },
-      c: {
-        next: "a",
-        prompt: "Några av er kanske missade det, så jag säger det igen:",
+      "160": {
+        next: "1126",
+        prompt: "Ja, då var vi av med honom!",
+        pdfPage: 8,
+        pdfLocationOnPage: 0.4,
+      },
+      "1126": {
+        next: "11",
+        prompt: "Vad är tårtan till?",
+        pdfPage: 48,
+        pdfLocationOnPage: 0.48,
       },
     };
-    this.history = ["a"];
+    this.history = ["1126"];
     this.script = script;
   }
 

--- a/src/tsx/coreConnection.tsx
+++ b/src/tsx/coreConnection.tsx
@@ -45,7 +45,6 @@ class DummyCoreConnection extends EventTarget implements ICoreConnection {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   constructor(address: string) {
     super();
-    // TODO: Use real lines with correct locations
     this.nodes = {
       "11": {
         next: "160",

--- a/src/tsx/liveScreen.tsx
+++ b/src/tsx/liveScreen.tsx
@@ -7,17 +7,17 @@ import { INodeCollection } from "./types";
 
 import style from "../less/liveScreen.module.less";
 
+interface IProps {
+  coreConnection: ICoreConnection;
+}
 interface IState {
   nodes: INodeCollection;
   history: string[];
   script: string;
 }
 
-class LiveScreen extends React.PureComponent<
-  { coreConnection: ICoreConnection },
-  IState
-> {
-  constructor(props: { coreConnection: ICoreConnection }) {
+class LiveScreen extends React.PureComponent<IProps, IState> {
+  constructor(props: IProps) {
     super(props);
     this.state = { nodes: {}, history: [], script: null };
     this.handleKey = this.handleKey.bind(this);
@@ -33,11 +33,19 @@ class LiveScreen extends React.PureComponent<
   }
 
   public render(): JSX.Element {
+    const currentNodeId = this.state.history[this.state.history.length - 1];
+    const currentNode = this.state.nodes[currentNodeId];
     return (
       <div className={style.screen}>
         <StatusView />
         <Timeline nodes={this.state.nodes} history={this.state.history} />
-        <PdfViewer script={this.state.script} />
+        <PdfViewer
+          script={this.state.script}
+          currentPage={currentNode ? currentNode.pdfPage : 0}
+          currentLocationOnPage={
+            currentNode ? currentNode.pdfLocationOnPage : 0
+          }
+        />
       </div>
     );
   }

--- a/src/tsx/liveScreen.tsx
+++ b/src/tsx/liveScreen.tsx
@@ -14,12 +14,18 @@ interface IState {
   nodes: INodeCollection;
   history: string[];
   script: string;
+  autoscrollScript: boolean;
 }
 
 class LiveScreen extends React.PureComponent<IProps, IState> {
   constructor(props: IProps) {
     super(props);
-    this.state = { nodes: {}, history: [], script: null };
+    this.state = {
+      nodes: {},
+      history: [],
+      script: null,
+      autoscrollScript: true,
+    };
     this.handleKey = this.handleKey.bind(this);
   }
 
@@ -50,6 +56,7 @@ class LiveScreen extends React.PureComponent<IProps, IState> {
             currentNode ? currentNode.pdfLocationOnPage : 0
           }
           focusY={200}
+          scrollToCurrentLocation={this.state.autoscrollScript}
         />
       </div>
     );
@@ -74,6 +81,8 @@ class LiveScreen extends React.PureComponent<IProps, IState> {
     if (document.activeElement === document.body && !event.repeat) {
       if (event.key === " ") {
         this.props.coreConnection.nextNode();
+      } else if (event.key === "s") {
+        this.setState({ autoscrollScript: !this.state.autoscrollScript });
       }
     }
   }

--- a/src/tsx/liveScreen.tsx
+++ b/src/tsx/liveScreen.tsx
@@ -38,13 +38,18 @@ class LiveScreen extends React.PureComponent<IProps, IState> {
     return (
       <div className={style.screen}>
         <StatusView />
-        <Timeline nodes={this.state.nodes} history={this.state.history} />
+        <Timeline
+          nodes={this.state.nodes}
+          history={this.state.history}
+          focusY={200}
+        />
         <PdfViewer
           script={this.state.script}
           currentPage={currentNode ? currentNode.pdfPage : 0}
           currentLocationOnPage={
             currentNode ? currentNode.pdfLocationOnPage : 0
           }
+          focusY={200}
         />
       </div>
     );

--- a/src/tsx/pdfViewer.tsx
+++ b/src/tsx/pdfViewer.tsx
@@ -64,7 +64,6 @@ class PdfViewer extends React.PureComponent<IProps, IState> {
   }
 
   private scrollToLocation(page: number, locationOnPage: number): void {
-    // const pageHeight = this.state.pdfWidth * Math.sqrt(2); // Assume A4 size
     const container = document.getElementById(this.state.id);
     const allPages = container.children[0];
     const { height } = allPages.getBoundingClientRect();

--- a/src/tsx/pdfViewer.tsx
+++ b/src/tsx/pdfViewer.tsx
@@ -3,32 +3,66 @@ import { Document, Page } from "react-pdf/dist/esm/entry.webpack";
 
 import style from "../less/pdfViewer.module.less";
 
+interface IProps {
+  script: string;
+  currentPage: number;
+  currentLocationOnPage: number;
+}
+
 interface IState {
   id: string;
   pdfWidth: number;
+  pdfHeight: number;
   numPages: number;
+  loadedPages: number; // To keep track of when we've fully loaded
 }
 
-class PdfViewer extends React.PureComponent<{ script: string }, IState> {
-  constructor(props: { script: string }) {
+class PdfViewer extends React.PureComponent<IProps, IState> {
+  constructor(props: IProps) {
     super(props);
     // Create a random ID, to avoid collisions if we ever have multiple
     // PDF viewers.
     this.state = {
       id: `pdfViewer${Math.round(Math.random() * 10000000)}`,
       pdfWidth: 0,
+      pdfHeight: 0,
       numPages: 0,
+      loadedPages: 0,
     };
   }
 
   public componentDidMount(): void {
-    const { width } = document
+    const { width, height } = document
       .getElementById(this.state.id)
       .getBoundingClientRect();
     // This will only grow the container, never shrink it.
     // Since we only do it when mounting it's fine for now.
     this.setState({
       pdfWidth: width,
+      pdfHeight: height,
+    });
+  }
+
+  public componentDidUpdate(prevProps: IProps, prevState: IState): void {
+    if (
+      this.props.currentPage !== prevProps.currentPage ||
+      this.props.currentLocationOnPage !== prevProps.currentLocationOnPage ||
+      (this.state.numPages !== 0 &&
+        this.state.loadedPages !== prevState.loadedPages &&
+        this.state.loadedPages === this.state.numPages)
+    ) {
+      this.scrollToLocation(
+        this.props.currentPage,
+        this.props.currentLocationOnPage,
+      );
+    }
+  }
+
+  private scrollToLocation(page: number, locationOnPage: number): void {
+    const pageHeight = this.state.pdfWidth * Math.sqrt(2); // Assume A4 size
+    document.getElementById(this.state.id).scrollTo({
+      top: (page + locationOnPage) * pageHeight - 0.5 * this.state.pdfHeight,
+      behavior: "smooth",
     });
   }
 
@@ -48,6 +82,9 @@ class PdfViewer extends React.PureComponent<{ script: string }, IState> {
               width={this.state.pdfWidth}
               renderAnnotationLayer={false}
               renderTextLayer={false}
+              onLoadSuccess={() => {
+                this.setState({ loadedPages: this.state.loadedPages + 1 });
+              }}
             />
           ))}
         </Document>

--- a/src/tsx/pdfViewer.tsx
+++ b/src/tsx/pdfViewer.tsx
@@ -7,12 +7,12 @@ interface IProps {
   script: string;
   currentPage: number;
   currentLocationOnPage: number;
+  focusY: number;
 }
 
 interface IState {
   id: string;
   pdfWidth: number;
-  pdfHeight: number;
   numPages: number;
   loadedPages: number; // To keep track of when we've fully loaded
 }
@@ -25,21 +25,19 @@ class PdfViewer extends React.PureComponent<IProps, IState> {
     this.state = {
       id: `pdfViewer${Math.round(Math.random() * 10000000)}`,
       pdfWidth: 0,
-      pdfHeight: 0,
       numPages: 0,
       loadedPages: 0,
     };
   }
 
   public componentDidMount(): void {
-    const { width, height } = document
+    const { width } = document
       .getElementById(this.state.id)
       .getBoundingClientRect();
     // This will only grow the container, never shrink it.
     // Since we only do it when mounting it's fine for now.
     this.setState({
       pdfWidth: width,
-      pdfHeight: height,
     });
   }
 
@@ -59,9 +57,13 @@ class PdfViewer extends React.PureComponent<IProps, IState> {
   }
 
   private scrollToLocation(page: number, locationOnPage: number): void {
-    const pageHeight = this.state.pdfWidth * Math.sqrt(2); // Assume A4 size
-    document.getElementById(this.state.id).scrollTo({
-      top: (page + locationOnPage) * pageHeight - 0.5 * this.state.pdfHeight,
+    // const pageHeight = this.state.pdfWidth * Math.sqrt(2); // Assume A4 size
+    const container = document.getElementById(this.state.id);
+    const allPages = container.children[0];
+    const { height } = allPages.getBoundingClientRect();
+    const pageHeight = height / this.state.numPages;
+    container.scrollTo({
+      top: (page + locationOnPage) * pageHeight - this.props.focusY,
       behavior: "smooth",
     });
   }

--- a/src/tsx/pdfViewer.tsx
+++ b/src/tsx/pdfViewer.tsx
@@ -8,6 +8,7 @@ interface IProps {
   currentPage: number;
   currentLocationOnPage: number;
   focusY: number;
+  scrollToCurrentLocation: boolean;
 }
 
 interface IState {
@@ -42,12 +43,18 @@ class PdfViewer extends React.PureComponent<IProps, IState> {
   }
 
   public componentDidUpdate(prevProps: IProps, prevState: IState): void {
-    if (
+    const changedLocation =
       this.props.currentPage !== prevProps.currentPage ||
-      this.props.currentLocationOnPage !== prevProps.currentLocationOnPage ||
-      (this.state.numPages !== 0 &&
-        this.state.loadedPages !== prevState.loadedPages &&
-        this.state.loadedPages === this.state.numPages)
+      this.props.currentLocationOnPage !== prevProps.currentLocationOnPage;
+    const justFinishedLoading =
+      this.state.numPages !== 0 &&
+      this.state.loadedPages !== prevState.loadedPages &&
+      this.state.loadedPages === this.state.numPages;
+    const justEnabledScrolling =
+      this.props.scrollToCurrentLocation && !prevProps.scrollToCurrentLocation;
+    if (
+      this.props.scrollToCurrentLocation &&
+      (changedLocation || justFinishedLoading || justEnabledScrolling)
     ) {
       this.scrollToLocation(
         this.props.currentPage,

--- a/src/tsx/types.tsx
+++ b/src/tsx/types.tsx
@@ -1,6 +1,8 @@
 interface INode {
   next: string;
   prompt: string;
+  pdfPage: number;
+  pdfLocationOnPage: number;
 }
 
 interface INodeCollection {


### PR DESCRIPTION
When going to the next node in the timeline, scroll to the corresponding line in the script. The user can toggle this behavior with the 's' key.