### PR TITLE
Only install dependencies when needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,19 @@
 
 default: build
 
-init:
+node_modules: package.json package-lock.json
 	npm ci
 
-build: init
+init: node_modules
+
+build: node_modules
 	npm run build
 
-watch: init
+watch: node_modules
 	npm run watch
 
-serve: init
+serve: node_modules
 	npm run serve
 
-dev: init
+dev: node_modules
 	npm run dev

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ When using `make`, installing of dependencies will be done automatically and `ma
 
 The easiest way to get started should be to run `make dev`, which will
 
-1.  install dependencies,
+1.  install dependencies if needed,
 2.  build the project,
 3.  start a server for the project,
 4.  open a web browser to the project,

--- a/browser-sync.config.js
+++ b/browser-sync.config.js
@@ -12,5 +12,5 @@ module.exports = {
   server: {
     baseDir: path.resolve(__dirname, "./dist"),
   },
-  startPath: "/?core=fake",
+  startPath: `/?core=${process.env.CORE || "fake"}`,
 };

--- a/browser-sync.config.js
+++ b/browser-sync.config.js
@@ -12,5 +12,5 @@ module.exports = {
   server: {
     baseDir: path.resolve(__dirname, "./dist"),
   },
-  startPath: `/?core=${process.env.CORE || "fake"}`,
+  startPath: `/?core=${encodeURIComponent(process.env.CORE) || "fake"}`,
 };

--- a/src/tsx/coreConnection.tsx
+++ b/src/tsx/coreConnection.tsx
@@ -162,7 +162,7 @@ class RealCoreConnection extends EventTarget implements ICoreConnection {
   }
 
   public handshake(): void {
-    this.socket = new WebSocket(`ws://${this.address}:8001`);
+    this.socket = new WebSocket(`ws://${this.address}`);
     this.socket.addEventListener("open", () => {
       this.socket.send(JSON.stringify({ client: "ui" }));
     });


### PR DESCRIPTION
Update the makefile so that 'make dev' will only install
dependencies if package.json or package-lock.json has
been updated since the last time dependencies were installed.