### PR TITLE
Add basic status view for video element

### DIFF
--- a/src/less/statusView.module.less
+++ b/src/less/statusView.module.less
@@ -5,6 +5,12 @@
     height: 100%;
     overflow-y: auto;
 }
+.temporarilyRemoved {
+    display: none;
+}
+.temporarilyDisabled {
+    opacity: 0.3;
+}
 
 .textArea {
     font-style: italic;
@@ -17,7 +23,15 @@
     margin-bottom: 0.5em;
 }
 
-.audioName {
+.videoInfo {
+    display: grid;
+    grid-template-columns: auto 2em 2em 2em 2em 2em;
+    grid-template-rows: auto auto;
+    margin-bottom: 0.5em;
+}
+
+.audioName,
+.videoName {
     grid-row-start: 1;
     grid-row-end: 2;
     grid-column: 1;
@@ -25,21 +39,26 @@
     white-space: nowrap;
     line-height: 1.4em;
 }
-.audioAction {
+.audioAction,
+.videoAction {
     text-align: center;
     font-size: 1.5em;
     padding: 0.15em 0.15em 0em 0.15em;
     margin: 0em 0em 0.2em 0em;
 }
-.audioLoop.looping {
+.audioLoop.looping,
+.videoLoop.looping {
     background-color: #f5deb340;
 }
-.audioAction:hover {
+.audioAction:hover,
+.videoAction:hover {
     cursor: pointer;
     background-color: #f5deb360;
 }
 .audioStopEnabled,
-.audioStopEnabled:hover {
+.audioStopEnabled:hover,
+.videoStopEnabled,
+.videoStopEnabled:hover {
     background: #ff000060;
 }
 .volumeValue {

--- a/src/tsx/coreConnection.tsx
+++ b/src/tsx/coreConnection.tsx
@@ -327,6 +327,18 @@ class RealCoreConnection extends EventTarget implements ICoreConnection {
         message.params["entityId"] = event.entityId;
         message.params["volume"] = event.numericValue;
         break;
+      case "destroy":
+        message.cmd = "destroy";
+        message.params["entityId"] = event.entityId;
+        break;
+      case "hide":
+        message.cmd = "hide";
+        message.params["entityId"] = event.entityId;
+        break;
+      case "show":
+        message.cmd = "show";
+        message.params["entityId"] = event.entityId;
+        break;
       default:
         console.log(`Unhandled effect action event: ${event.action_type}`);
         break;

--- a/src/tsx/statusView/progressBar.tsx
+++ b/src/tsx/statusView/progressBar.tsx
@@ -48,9 +48,16 @@ class ProgressBar extends React.PureComponent<IProps, IState> {
 
   public updateTime(): void {
     const now = Date.now();
+    let currentTime = this.state.currentTime;
+    let lastUpdated = this.state.lastUpdated;
+    if (this.state.lastUpdated < this.props.lastUpdated) {
+      currentTime = this.props.currentTime;
+      lastUpdated = this.props.lastUpdated;
+    }
+
     if (this.props.running) {
-      const timeDiff = now - this.state.lastUpdated;
-      let newTime = this.state.currentTime + timeDiff / 1000;
+      const timeDiff = now - lastUpdated;
+      let newTime = currentTime + timeDiff / 1000;
       if (this.props.looping) {
         newTime = newTime % this.props.duration;
       } else {

--- a/src/tsx/statusView/statusEffect.tsx
+++ b/src/tsx/statusView/statusEffect.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { IEmpty, IEffect, EffectType, IEffectActionEvent } from "../types";
 import style from "../../less/statusView.module.less";
 import { AudioEffect } from "./audioEffect";
+import { VideoEffect } from "./videoEffect";
 
 interface IProps {
   effect: IEffect;
@@ -26,7 +27,7 @@ function EffectContent(props: IProps) {
     case EffectType.Audio:
       return <AudioEffect {...props} />;
     case EffectType.Video:
-      return VideoEffectContent(props);
+      return <VideoEffect {...props} />;
     case EffectType.Image:
       return ImageEffectContent(props);
     default:
@@ -48,10 +49,6 @@ function BaseEffectContent(props: IProps): JSX.Element {
 
 function ImageEffectContent(props: IProps): JSX.Element {
   return <div className={style.textArea}>{props.effect.name} [IMAGE]</div>;
-}
-
-function VideoEffectContent(props: IProps): JSX.Element {
-  return <div className={style.textArea}>{props.effect.name} [VIDEO]</div>;
 }
 
 export { StatusEffect };

--- a/src/tsx/statusView/videoEffect.tsx
+++ b/src/tsx/statusView/videoEffect.tsx
@@ -1,0 +1,198 @@
+import * as React from "react";
+
+import style from "../../less/statusView.module.less";
+import { EffectType, IEffect, IEffectActionEvent } from "../types";
+import { ProgressBar } from "./progressBar";
+
+import {
+  MdPlayArrow,
+  MdPause,
+  MdStop,
+  MdLoop,
+  MdVolumeOff,
+  MdVolumeUp,
+  MdOutlineImage,
+  MdOutlineHideImage,
+} from "react-icons/md";
+
+interface IState {
+  volume: number;
+  stopEnabled: boolean;
+}
+
+interface IProps {
+  effect: IEffect;
+  onEffectAction: (event: IEffectActionEvent) => void;
+}
+
+class VideoEffect extends React.PureComponent<IProps, IState> {
+  constructor(props: IProps) {
+    super(props);
+    this.state = {
+      volume: this.props.effect.volume ? this.props.effect.volume : 50,
+      stopEnabled: false,
+    };
+  }
+
+  public render(): JSX.Element {
+    return (
+      <div>
+        <div className={style.videoInfo}>
+          <div className={style.videoName}>{this.props.effect.name}</div>
+          <div
+            className={`${style.videoAction} ${style.videoMute} ${style.temporarilyDisabled}`}
+            onClick={this.sendToggleMute.bind(this)}
+          >
+            {this.getMuteButton()}
+          </div>
+          <div
+            className={`${style.videoAction} ${style.videoPlayPause}`}
+            onClick={this.sendPlayPause.bind(this)}
+          >
+            {this.getPlayPauseButton()}
+          </div>
+          <div
+            className={`${style.videoAction} ${style.videoHide}`}
+            onClick={this.sendToggleHidden.bind(this)}
+          >
+            {this.getHideButton()}
+          </div>
+          <div
+            className={`${style.videoAction} ${style.videoLoop} ${
+              this.props.effect.looping ? style.looping : ""
+            }`}
+            onClick={this.sendToggleLoop.bind(this)}
+          >
+            <MdLoop />
+          </div>
+          <div
+            className={`${style.videoAction} ${style.videoStop} ${
+              this.state.stopEnabled ? style.videoStopEnabled : ""
+            }`}
+            onClick={this.sendStop.bind(this)}
+          >
+            <MdStop />
+          </div>
+          <div className={`${style.volumeValue} ${style.temporarilyRemoved}`}>
+            {this.props.effect.volume}
+          </div>
+          <input
+            className={`${style.volumeInput} ${style.slider} ${style.temporarilyRemoved}`}
+            type="range"
+            min="0"
+            max="100"
+            value={this.props.effect.volume}
+            onChange={(e) => this.updateVolume(parseInt(e.target.value))}
+          />
+        </div>
+        <ProgressBar
+          duration={this.props.effect.duration}
+          currentTime={this.props.effect.currentTime}
+          lastUpdated={this.props.effect.lastSync}
+          looping={this.props.effect.looping}
+          running={this.props.effect.playing}
+        />
+      </div>
+    );
+  }
+
+  private getMuteButton(): JSX.Element {
+    if (this.props.effect.muted) {
+      return <MdVolumeOff />;
+    } else {
+      return <MdVolumeUp />;
+    }
+  }
+
+  private getPlayPauseButton(): JSX.Element {
+    if (this.props.effect.playing) {
+      return <MdPause />;
+    } else {
+      return <MdPlayArrow />;
+    }
+  }
+
+  private getHideButton(): JSX.Element {
+    if (this.props.effect.visible) {
+      return <MdOutlineImage />;
+    } else {
+      return <MdOutlineHideImage />;
+    }
+  }
+
+  private effectTypeAsString(): string {
+    switch (this.props.effect.type) {
+      case EffectType.Video:
+        return "video";
+      case EffectType.Image:
+        return "image";
+      case EffectType.WebPage:
+        return "web";
+      default:
+        return "unknown";
+    }
+  }
+
+  private updateVolume(volume: number): void {
+    this.setState({ ...this.state, volume: volume });
+    this.props.onEffectAction({
+      entityId: this.props.effect.entityId,
+      action_type: "change_volume",
+      media_type: this.effectTypeAsString(),
+      numericValue: volume,
+    });
+  }
+
+  private sendToggleHidden(): void {
+    const eventType = this.props.effect.visible ? "hide" : "show";
+    this.props.onEffectAction({
+      entityId: this.props.effect.entityId,
+      action_type: eventType,
+      media_type: this.effectTypeAsString(),
+    });
+  }
+
+  private sendToggleMute(): void {
+    this.props.onEffectAction({
+      entityId: this.props.effect.entityId,
+      action_type: "toggle_mute",
+      media_type: this.effectTypeAsString(),
+    });
+  }
+
+  private sendPlayPause(): void {
+    const eventType = this.props.effect.playing ? "pause" : "play";
+    this.props.onEffectAction({
+      entityId: this.props.effect.entityId,
+      action_type: eventType,
+      media_type: this.effectTypeAsString(),
+    });
+  }
+
+  private sendStop(): void {
+    if (!this.state.stopEnabled) {
+      this.setStopEnabled(true);
+      setTimeout(this.setStopEnabled.bind(this, false), 2000);
+    } else {
+      this.props.onEffectAction({
+        entityId: this.props.effect.entityId,
+        action_type: "destroy",
+        media_type: this.effectTypeAsString(),
+      });
+    }
+  }
+
+  private sendToggleLoop(): void {
+    this.props.onEffectAction({
+      entityId: this.props.effect.entityId,
+      action_type: "toggle_loop",
+      media_type: this.effectTypeAsString(),
+    });
+  }
+
+  private setStopEnabled(enabled: boolean): void {
+    this.setState({ ...this.state, stopEnabled: enabled });
+  }
+}
+
+export { VideoEffect };

--- a/src/tsx/types.tsx
+++ b/src/tsx/types.tsx
@@ -14,6 +14,7 @@ enum EffectType {
   Audio,
   Video,
   Image,
+  WebPage,
 }
 
 interface IEffect {
@@ -27,6 +28,7 @@ interface IEffect {
   looping?: boolean;
   muted?: boolean;
   volume?: number;
+  visible?: boolean;
 }
 
 interface IEffectActionEvent {


### PR DESCRIPTION
See matching PRs https://github.com/kulturkrock/screencrash-components/pull/69 and https://github.com/kulturkrock/screencrash-core/pull/15.

Note that this only implements the graphical part, adding the audio as well is a todo for the future.