### PR TITLE
Revert changes for windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "node_modules\\.bin\\webpack",
-    "watch": "node_modules\\.bin\\webpack --watch",
-    "serve": "node_modules\\.bin\\browser-sync start --config browser-sync.config.js",
-    "dev": "node_modules\\.bin\\npm-run-all --parallel watch serve"
+    "build": "node_modules/.bin/webpack",
+    "watch": "node_modules/.bin/webpack --watch",
+    "serve": "node_modules/.bin/browser-sync start --config browser-sync.config.js",
+    "dev": "node_modules/.bin/npm-run-all --parallel watch serve"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Windows needs to grow up and handle slash like everyone else. Anyhoot, the backslash change was never intended to be commited in the first place so let's revert it.