### PR TITLE
Add shortcut support

### DIFF
--- a/src/less/shortcutView.module.less
+++ b/src/less/shortcutView.module.less
@@ -1,0 +1,21 @@
+.container {
+    padding: 0em;
+}
+.container button {
+    border-top: 0px;
+    border-bottom: 0px;
+    padding: 1em 1em;
+}
+
+.shortcut {
+    display: flex;
+    padding: 0em 0em 0em 1em;
+    border-bottom: 1px solid;
+}
+.shortcut > div.shortcutTitle {
+    flex: 1;
+    padding: 0.5em 0em;
+    vertical-align: middle;
+    line-height: 1.5em;
+    cursor: default;
+}

--- a/src/tsx/coreMessages.tsx
+++ b/src/tsx/coreMessages.tsx
@@ -1,3 +1,7 @@
+interface PredefinedActionsTrigger {
+  messageType: string;
+  actions: string[];
+}
 interface OnTheFlyAction {
   messageType: string;
   target_component: string;
@@ -14,4 +18,9 @@ interface ComponentRestartMessage {
   componentId: string;
 }
 
-export { OnTheFlyAction, ComponentResetMessage, ComponentRestartMessage };
+export {
+  PredefinedActionsTrigger,
+  OnTheFlyAction,
+  ComponentResetMessage,
+  ComponentRestartMessage,
+};

--- a/src/tsx/shortcutView.tsx
+++ b/src/tsx/shortcutView.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { IEmpty } from "types";
+
+import style from "../less/shortcutView.module.less";
+import { IShortcut } from "./types";
+
+interface IProps {
+  shortcuts: IShortcut[];
+  onTriggerPredefinedActions: (actions: string[]) => void;
+}
+
+class ShortcutView extends React.PureComponent<IProps, IEmpty> {
+  public render(): JSX.Element {
+    return (
+      <div className={style.container}>
+        {this.props.shortcuts.map((shortcut, i) => (
+          <div key={`shortcut_${i}`} className={style.shortcut}>
+            <div className={style.shortcutTitle} title={shortcut.hotkey || ""}>
+              {shortcut.title}
+            </div>
+            <button onClick={this.triggerActions.bind(this, shortcut.actions)}>
+              Trigger
+            </button>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  private triggerActions(actions: string[]): void {
+    this.props.onTriggerPredefinedActions(actions);
+  }
+}
+
+export { ShortcutView };

--- a/src/tsx/statusView.tsx
+++ b/src/tsx/statusView.tsx
@@ -6,11 +6,13 @@ import { ComponentView } from "./componentView";
 import { OnTheFlyAction } from "./coreMessages";
 import { EffectView } from "./effectView/effectView";
 import { LogView } from "./logView";
+import { ShortcutView } from "./shortcutView";
 import {
   IComponentState,
   IEffect,
   IEffectActionEvent,
   ILogMessage,
+  IUIConfig,
 } from "./types";
 
 interface ITab {
@@ -25,11 +27,14 @@ const tabs = {
   components: "components",
   logs: "log",
   inventory: "inventory",
+  shortcuts: "shortcuts",
 };
 
 interface IProps {
+  uiConfig: IUIConfig;
   effects: IEffect[];
   onOnTheFlyAction: (action: OnTheFlyAction) => void;
+  onTriggerPredefinedActions: (actions: string[]) => void;
   onEffectAction: (event: IEffectActionEvent) => void;
   onComponentReset: (componentId: string) => void;
   onComponentRestart: (componentId: string) => void;
@@ -97,6 +102,11 @@ class StatusView extends React.PureComponent<IProps, IState> {
         name: "Components",
         icon: <span className={style.shortName}>COMP</span>,
         count: this.props.components.length,
+      },
+      {
+        key: tabs.shortcuts,
+        name: "Shortcuts",
+        icon: <span className={style.shortName}>SC</span>,
       },
       {
         key: tabs.logs,
@@ -190,6 +200,13 @@ function TabContent(propsData: IPropsTab): JSX.Element {
       <LogView
         logMessages={propsData.props.logMessages}
         onClearMessages={propsData.props.onClearLogMessages}
+      />
+    );
+  } else if (propsData.tabName === tabs.shortcuts) {
+    return (
+      <ShortcutView
+        shortcuts={propsData.props.uiConfig.shortcuts}
+        onTriggerPredefinedActions={propsData.props.onTriggerPredefinedActions}
       />
     );
   } else if (propsData.tabName === tabs.inventory) {

--- a/src/tsx/types.tsx
+++ b/src/tsx/types.tsx
@@ -22,6 +22,16 @@ interface INodeCollection {
   [index: string]: INode;
 }
 
+interface IShortcut {
+  title: string;
+  hotkey: string | undefined;
+  actions: string[];
+}
+
+interface IUIConfig {
+  shortcuts: IShortcut[];
+}
+
 enum EffectType {
   Other,
   Audio,
@@ -83,6 +93,8 @@ export {
   IAction,
   INode,
   INodeCollection,
+  IShortcut,
+  IUIConfig,
   IEffect,
   EffectType,
   IEffectActionEvent,


### PR DESCRIPTION
Add support for handling UI config, particularly shortcuts. A new view has been added for shortcuts and appropriate key press bindings was bound according to the config contents.

Screenshot of view:
![image](https://user-images.githubusercontent.com/6124607/160066668-3a547aad-497b-4412-87be-ccbffc843ecf.png)

