### PR TITLE
Hide notifications when hide item section

### DIFF
--- a/src/tsx/components/inventory.tsx
+++ b/src/tsx/components/inventory.tsx
@@ -233,6 +233,18 @@ class InventoryView extends React.PureComponent<IProps, IEmpty> {
   }
 
   setItemsVisibility(visibility: boolean): void {
+    if (!visibility) {
+      // Hide item animations before hiding items section
+      const action: OnTheFlyAction = {
+        messageType: "component-action",
+        target_component: "inventory",
+        cmd: "clear_item_animations",
+        assets: [],
+        params: {},
+      };
+      this.props.onOnTheFlyAction(action);
+    }
+
     const action: OnTheFlyAction = {
       messageType: "component-action",
       target_component: "inventory",


### PR DESCRIPTION
When doing a manual hide of the item section the notifications are still visible. They shouldnt be. This fixes that.